### PR TITLE
Check created snapshot against SQL Server instead of files on disk

### DIFF
--- a/test/test-integration/MssqlSnapshot.create.spec.js
+++ b/test/test-integration/MssqlSnapshot.create.spec.js
@@ -1,6 +1,6 @@
 import createSnapshotUtility from '../../src/mssql-snapshot';
 import databaseConfig from '../../src/databaseConfig';
-import {deleteSnapshot, getDbMeta, fileExists} from './testUtilities';
+import { deleteSnapshot, snapshotExists } from './testUtilities';
 
 describe('when creating a named sql snapshot', function() {
 	let target = null;
@@ -23,10 +23,5 @@ describe('when creating a named sql snapshot with valid configuration', function
 
 	afterEach(() => deleteSnapshot(snapshotName));
 
-	it('the snapshot file exists on disk', function() {
-		return getDbMeta(snapshotName).then((result) => {
-			return fileExists(result.PhysicalName).should.eventually.eql(true);
-		});
-	});
-
+	it('the snapshot file exists on disk', () => snapshotExists(snapshotName).should.eventually.eql(true));
 });


### PR DESCRIPTION
In doing this, the test passing/failing is not dependent on whether the user running the test has read rights to the directory where the snapshots are saved.

Closes #6.